### PR TITLE
Video lightbox fix (CSS aspect-ratio approach)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,9 @@
         <span class="close cursor" onclick="closeLightBox()">&times;</span>
         <div class="lightbox-content">
             <img id="lightbox-im" src="img_nature_wide.jpg">
+            <div id="lightbox-video-container" class="lightbox-video-container" style="display:none;">
+                <iframe id="lightbox-video" src="" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+            </div>
             <div class="lightbox-caption-container">
                 <h2 id="lightbox-caption"></h2>
                 <a class="github-button" id="lighbox-request-print">REQUEST PRINT</a>

--- a/render.js
+++ b/render.js
@@ -241,6 +241,17 @@ function initializePage() {
 function openLightBox(img_elem, caption) {
     pauseBackgroundVideo();
 
+    var videoContainer = document.getElementById("lightbox-video-container");
+    var lightboxVideo = document.getElementById("lightbox-video");
+    if (videoContainer) {
+        videoContainer.style.display = 'none';
+    }
+    if (lightboxVideo) {
+        lightboxVideo.removeAttribute('src');
+    }
+
+    document.getElementById("lightbox-im").style.display = 'block';
+
     if (caption === '') {
         caption = img_elem.parentElement.parentElement.firstElementChild.textContent;
     }
@@ -260,11 +271,47 @@ function openLightBox(img_elem, caption) {
     lightbox.classList.remove('hidden');
 }
 
+function openVideoLightBox(embedUrl, sourceType, caption, event) {
+    if (event) {
+        event.stopPropagation();
+    }
+    pauseBackgroundVideo();
+
+    document.getElementById("lightbox-im").style.display = 'none';
+    document.getElementById("lighbox-request-print").style.display = 'none';
+
+    if (caption) {
+        document.getElementById("lightbox-caption").textContent = caption;
+    }
+
+    var autoplayUrl = embedUrl.indexOf('?') >= 0 ? embedUrl + '&autoplay=1' : embedUrl + '?autoplay=1';
+    var videoContainer = document.getElementById("lightbox-video-container");
+    var lightboxVideo = document.getElementById("lightbox-video");
+    lightboxVideo.src = autoplayUrl;
+    videoContainer.style.display = 'block';
+
+    var lightbox = document.getElementById("lightbox");
+    lightbox.classList.add('visible');
+    lightbox.classList.remove('hidden');
+}
+
 function closeLightBox() {
     playBackgroundVideo();
 
-    document.getElementById("lightbox-im").removeAttribute('src')
+    var videoContainer = document.getElementById("lightbox-video-container");
+    var lightboxVideo = document.getElementById("lightbox-video");
+    if (videoContainer) {
+        videoContainer.style.display = 'none';
+    }
+    if (lightboxVideo) {
+        lightboxVideo.removeAttribute('src');
+    }
 
+    document.getElementById("lightbox-im").removeAttribute('src');
+    document.getElementById("lightbox-im").style.display = 'block';
+    document.getElementById("lighbox-request-print").style.display = '';
+
+    var lightbox = document.getElementById("lightbox");
     lightbox.classList.remove('visible');
     lightbox.classList.add('hidden');
 }

--- a/static/templates/vimeo_embed.mustache
+++ b/static/templates/vimeo_embed.mustache
@@ -1,6 +1,6 @@
 <div
     id="vimeo_{{vimeo_count}}"
-    class="vimeo_embed {{^thumbnail}}iframe-container{{/thumbnail}}"
+    class="vimeo_embed {{^thumbnail}}iframe-container video-clickable{{/thumbnail}}"
     {{#aspect_ratio}}style="padding-top: {{.}};"{{/aspect_ratio}}
     {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
     {{#loopend}}loopend="{{.}}"{{/loopend}}
@@ -16,6 +16,7 @@
         {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
         {{#loopend}}loopend="{{.}}"{{/loopend}}
     ></iframe>
+    <div class="video-overlay" onclick="openVideoLightBox('https://player.vimeo.com/video/{{vimeo}}?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479', 'vimeo', '', event);"></div>
     {{/thumbnail}}
 </div>
 

--- a/static/templates/youtube_embed.mustache
+++ b/static/templates/youtube_embed.mustache
@@ -1,6 +1,6 @@
 <div class="iframe-container video-clickable" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
     <iframe
-        src="https://www.youtube.com/embed/{{youtube}}?modestbranding=1&rel=0&controls=1&showinfo=0"
+        src="https://www.youtube.com/embed/{{youtube}}?controls=0"
         frameborder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen

--- a/static/templates/youtube_embed.mustache
+++ b/static/templates/youtube_embed.mustache
@@ -1,8 +1,9 @@
-<div class="iframe-container" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
-    <iframe 
-        src="https://www.youtube.com/embed/{{youtube}}?controls=0"
+<div class="iframe-container video-clickable" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
+    <iframe
+        src="https://www.youtube.com/embed/{{youtube}}?modestbranding=1&rel=0&controls=1&showinfo=0"
         frameborder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen
     ></iframe>
+    <div class="video-overlay" onclick="openVideoLightBox('https://www.youtube.com/embed/{{youtube}}', 'youtube', '', event);"></div>
 </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -436,6 +436,26 @@ li.nav_inactive ul {
     pointer-events: none;
 }
 
+.video-clickable {
+    cursor: pointer;
+}
+
+.video-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0);
+    transition: background 0.3s;
+}
+
+.video-clickable:hover .video-overlay {
+    background: rgba(0, 0, 0, 0.1);
+}
+
 .iframe-container iframe {
    border: 0;
    height: 100%;
@@ -542,6 +562,24 @@ li.nav_inactive ul {
   margin-left: auto;
   margin-right: auto;
   padding-top: 5%;
+}
+
+.lightbox-video-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  max-height: calc(100vh - 48px - 150px);
+  overflow: hidden;
+  display: none;
+}
+
+.lightbox-video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
 }
 
 /* The Close Button */


### PR DESCRIPTION
## Summary
- Re-enables the video lightbox that was disabled in commit 8b28103 ("Comment out video lightbox headache for now")
- Applies Option A from the [video lightbox archaeology doc](https://github.com/frankieeder/life_automation/pull/113): CSS `aspect-ratio` container instead of `padding-top` hack
- Adds the video container DOM to index.html (was missing, not just commented out, in goal branch)
- Adds `openVideoLightBox()` to render.js with mutual exclusion against the image lightbox
- Adds `.video-overlay` click handlers to both vimeo_embed.mustache and youtube_embed.mustache
- Also fixes a pre-existing bug: bare `lightbox` variable reference in original `closeLightBox()` (now uses `getElementById`)

## Caveats — REQUIRES VISUAL REVIEW
- **The agent cannot visually verify lightbox layout in a browser.** This PR is a best-effort attempt informed by the archaeology research.
- The user has historically had recurring alignment issues in this exact area. Manual visual review is required before merge.
- If the alignment is still off, comment on this PR with what you see and we'll iterate.

## Test plan
- [ ] (User-side) `make run && make open` → click a video card → video lightbox opens with correct 16:9 aspect ratio
- [ ] (User-side) Verify resize at 320px, 768px, 1280px viewport widths
- [ ] (User-side) Open image lightbox in same session → confirm image still works (no regression)
- [ ] (User-side) Switch between video and image lightboxes → confirm mutual exclusion (one hides while other shows)
- [ ] (User-side) Close video lightbox → confirm iframe `src` is cleared (video stops playing)

## Out of scope
- Stripe / BUY PRINT (separate PRs in this dev cycle)
- Image lightbox (untouched logic)
- Layout overhaul from new-layout (intentionally not pulled)

## Before/after screenshots
<!-- User: please add screenshots after visual review -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)