### PR TITLE
Stripe polish: CI sync workflow, provider pins, dead-code removal, README

### DIFF
--- a/.github/workflows/stripe-sync.yml
+++ b/.github/workflows/stripe-sync.yml
@@ -1,0 +1,27 @@
+name: Stripe Sync
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform apply
+        working-directory: infra/stripe
+        env:
+          TF_VAR_stripe_api_key: ${{ secrets.STRIPE_API_KEY }}
+        run: |
+          terraform init
+          terraform apply -auto-approve
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: refresh payment_links.json via stripe-sync CI"
+          file_pattern: infra/stripe/payment_links.json

--- a/index.html
+++ b/index.html
@@ -104,7 +104,6 @@
             </div>
             <div class="lightbox-caption-container">
                 <h2 id="lightbox-caption"></h2>
-                <a class="github-button" id="lighbox-request-print">REQUEST PRINT</a>
                 <div class="buy-print-container">
                     <a class="github-button" id="lightbox-buy-print" target="_blank">BUY PRINT</a>
                     <div id="lightbox-buy-print-dropdown"></div>

--- a/infra/stripe/README.md
+++ b/infra/stripe/README.md
@@ -1,0 +1,27 @@
+# infra/stripe
+
+Terraform config for Stripe products, prices, shipping rates, and payment links.
+
+## Stripe API key
+
+Provide via any of:
+- `export TF_VAR_stripe_api_key=sk_...` before running terraform
+- A `terraform.tfvars` file (add to `.gitignore` — never commit)
+- Interactive prompt (terraform will ask if the var is unset)
+
+## Two providers
+
+- `stripe/stripe` — used for products, prices, and shipping rates
+- `andrewbaxter/stripe` (`stripealt`) — used for `stripe_payment_link`; the official provider does not support that resource
+
+## `data "external"` block
+
+Neither Stripe provider exposes the payment link `url` attribute as a readable output, so the `data "external"` blocks read it back directly from the Stripe API via `curl`/`jq` after `apply`.
+
+## Regenerating `payment_links.json`
+
+`.github/workflows/stripe-sync.yml` is the canonical path:
+1. Go to **Actions → Stripe Sync → Run workflow** in GitHub
+2. The workflow runs `terraform apply` and commits the refreshed `payment_links.json`
+
+Local `terraform apply` is for development only. Do NOT commit changes to `payment_links.json` from a local run — let CI do it to avoid drift.

--- a/infra/stripe/main.tf
+++ b/infra/stripe/main.tf
@@ -2,15 +2,19 @@ terraform {
   required_providers {
     stripe = {
       source  = "stripe/stripe"
-      version = "~> 0.0"
+      version = "~> 0.1"
     }
     stripealt = {
       source  = "andrewbaxter/stripe"
-      version = "~> 0.0"
+      version = "~> 0.0.24"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.0"
+      version = "~> 2.6"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
     }
   }
 }
@@ -100,6 +104,9 @@ resource "stripe_shipping_rate" "shipping_rates" {
     amount = each.value.fixed_amount_amount
     currency = "usd"
   }
+  # tax_behavior = "inclusive": the shipping price already includes tax in the
+  # displayed amount. If you intended to charge shipping + tax-on-top, set this
+  # to "exclusive". TODO: confirm desired behavior with Frankie before going live.
   tax_behavior = "inclusive"
   tax_code = "txcd_92010001"
   delivery_estimate {

--- a/render.js
+++ b/render.js
@@ -273,9 +273,6 @@ function openLightBox(img_elem, caption) {
 
     var url_parts = im_path.split('/');
     var image_id = url_parts[url_parts.length - 1];
-    var prefix = 'mailto:frankaeder@gmail.com?subject=';
-    var body = "&body=Hello there, I'd like a copy of image id " + image_id;
-    document.getElementById("lighbox-request-print").href = prefix + 'frankieeder.com Print Request' + body;
 
     var artwork_id = image_id.replace(/\.[^/.]+$/, '');
     var buy_print_elem = document.getElementById("lightbox-buy-print");
@@ -395,7 +392,6 @@ function openVideoLightBox(embedUrl, sourceType, caption, event) {
     pauseBackgroundVideo();
 
     document.getElementById("lightbox-im").style.display = 'none';
-    document.getElementById("lighbox-request-print").style.display = 'none';
 
     if (caption) {
         document.getElementById("lightbox-caption").textContent = caption;
@@ -426,7 +422,6 @@ function closeLightBox() {
 
     document.getElementById("lightbox-im").removeAttribute('src');
     document.getElementById("lightbox-im").style.display = 'block';
-    document.getElementById("lighbox-request-print").style.display = '';
 
     var lightbox = document.getElementById("lightbox");
     lightbox.classList.remove('visible');


### PR DESCRIPTION
## Summary
Stripe-related polish, rebased onto the goal branch after PR #13 merged. Replaces the auto-closed PR #14.

- Adds `.github/workflows/stripe-sync.yml` (manual-dispatch CI workflow that runs `terraform apply` and commits refreshed `payment_links.json`)
- Tightens Terraform provider pins per `.terraform.lock.hcl` (`stripe/stripe ~> 0.1`, `andrewbaxter/stripe ~> 0.0.24`, `hashicorp/local ~> 2.6`); adds missing `hashicorp/external ~> 2.3` to `required_providers`
- Comments `tax_behavior = "inclusive"` on shipping rates with a TODO for the user to confirm intent
- Removes dead REQUEST PRINT mailto code path (BUY PRINT is now the primary purchase flow)
- Adds `infra/stripe/README.md`

## History
PR #14 was opened against PR #13's branch (stacked). When PR #13 merged with `--delete-branch`, GitHub auto-closed PR #14 instead of retargeting it to the goal branch. This PR is the same content rebased onto the goal branch with `--onto`.

## Test plan
- [ ] (User-side) Manual review of README accuracy
- [ ] (User-side) Confirm `tax_behavior = "inclusive"` is correct for the shipping pricing model
- [ ] (User-side) `gh workflow list` should show `stripe-sync.yml` after merge

## Out of scope
- Per-artwork Stripe products (deferred — `client_reference_id` handle is sufficient for fulfillment)
- Auto-trigger of stripe-sync.yml (manual dispatch is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)