### PR TITLE
Add Cloudflare Workers config (.assetsignore + wrangler.jsonc)

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,0 +1,30 @@
+# Cloudflare Workers Static Assets ignore file (gitignore syntax).
+# Without this, wrangler ships .git/ and busts the 25 MiB asset limit.
+
+# git internals
+.git/
+.gitignore
+.gitmodules
+.htaccess
+
+# CI / repo metadata
+.github/
+
+# dev tooling (not served at runtime)
+Makefile
+imgproc.py
+requirements.txt
+
+# Stripe IaC source. payment_links.json is fetched at runtime — keep it.
+infra/stripe/main.tf
+infra/stripe/variants.json
+infra/stripe/.gitignore
+infra/stripe/.terraform.lock.hcl
+infra/stripe/README.md
+
+# mustache.js submodule (mustache.min.js at root is what's loaded)
+mustache.js/
+
+# editor / venv artifacts
+.idea/
+venv/

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "frankieeder-dev",
+  "compatibility_date": "2026-05-07",
+  "assets": {
+    "directory": "."
+  }
+}


### PR DESCRIPTION
## Summary
Two files needed to unblock Cloudflare Workers Static Assets preview deploys:

1. **\`.assetsignore\`** — keeps wrangler from shipping \`.git/\` (1.53 GiB pack file busts the 25 MiB asset limit)
2. **\`wrangler.jsonc\`** — required when wrangler runs \`versions upload\` (the preview-branch command). The first deploy worked because it used \`wrangler deploy\` which auto-generates the config in-place; preview branches use \`versions upload\` which does not.

## What \`.assetsignore\` excludes
- \`.git/\` and git config files (the size blocker)
- \`.github/\` (CI workflows aren't served at runtime)
- Dev tooling: \`Makefile\`, \`imgproc.py\`, \`requirements.txt\`
- Stripe IaC source (\`main.tf\`, \`variants.json\`, lockfile, README) — but **keeps** \`infra/stripe/payment_links.json\` since \`render.js\` fetches it at runtime
- \`mustache.js/\` submodule directory (the \`.min.js\` at root is what \`<script>\` actually loads)
- Editor / venv artifacts

## \`wrangler.jsonc\` shape
Minimal — just \`name\`, \`compatibility_date\`, and \`assets.directory: \".\"\`. No \`nodejs_compat\` flag (pure static), no observability binding (not needed).

## Known follow-up (NOT in this PR)
The build still spends ~90s running \`pip install -r requirements.txt\` because Cloudflare's build runner sees \`requirements.txt\` and assumes Python deps are needed. Fixing this requires a **dashboard** change — Settings → Builds & deployments → Build command → set to something like \`echo skip\` (or empty). Can't be done from the repo. Worth doing once everything else works, but it's a perf win, not a blocker.

## Test plan
- [ ] After merge, Cloudflare retriggers the goal-branch preview deploy
- [ ] Build succeeds (no \"Asset too large\", no \"Missing entry-point\")
- [ ] Preview URL serves the site correctly: thumbnails load, BUY PRINT dropdown populates from \`infra/stripe/payment_links.json\`

## Stack
Targets the goal branch \`frankieeder-com/buy-print-and-video\` (PR #16) so the preview deploy unblocks immediately. Becomes part of PR #16's diff to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)