### PR TITLE
Center BUY PRINT button (box-sizing fix)

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -496,6 +496,14 @@ li.nav_inactive ul {
     width: 300px;
 }
 
+/* width 300px on .github-button + padding 6px 75px without border-box
+   would render at 450px and overflow .buy-print-container. Constrain
+   to the container width here without affecting other .github-button
+   uses (e.g. CONTACT ME on /about) that aren't in a fixed-width parent. */
+#lightbox-buy-print {
+    box-sizing: border-box;
+}
+
 #lightbox-buy-print-dropdown {
     display: none;
     position: absolute;


### PR DESCRIPTION
## Summary
Surgical fix to a layout bug noticed during preview review: BUY PRINT button isn't centered.

## Root cause
\`.github-button\` has \`padding: 6px 75px\` (150px horizontal padding) and \`width: 300px\` with default \`box-sizing: content-box\`. Rendered width = \`300 + 150 = 450px\`. The button overflows its 300px-wide parent (\`.buy-print-container\`) by 75px on each side, which makes the container's centering look subtly off.

\`.buy-print-dropdown-item\` already has \`box-sizing: border-box\` (line 527) — the inconsistency was that the button itself didn't.

## Fix
Add \`box-sizing: border-box\` scoped to \`#lightbox-buy-print\` so the button respects the 300px width as its outer dimension. Don't touch \`.github-button\` globally — \`CONTACT ME\` on \`/about\` uses that class outside a fixed-width container and would shift visually if margins changed.

## Test plan
- [ ] (User-side) Reload preview URL, open any photo lightbox → BUY PRINT button visually centered
- [ ] (User-side) Open \`/about\` → CONTACT ME button still looks the same as before

## Stack
Targets the goal branch \`frankieeder-com/buy-print-and-video\` (PR #16). Stacks alongside the open assetsignore PR #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)