### PR TITLE
Disable video lightbox (defer to separate PR)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,6 @@
         <span class="close cursor" onclick="closeLightBox()">&times;</span>
         <div class="lightbox-content">
             <img id="lightbox-im" src="img_nature_wide.jpg">
-            <div id="lightbox-video-container" class="lightbox-video-container" style="display:none;">
-                <iframe id="lightbox-video" src="" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
-            </div>
             <div class="lightbox-caption-container">
                 <h2 id="lightbox-caption"></h2>
                 <div class="buy-print-container">

--- a/render.js
+++ b/render.js
@@ -252,17 +252,6 @@ function initializePage() {
 function openLightBox(img_elem, caption) {
     pauseBackgroundVideo();
 
-    var videoContainer = document.getElementById("lightbox-video-container");
-    var lightboxVideo = document.getElementById("lightbox-video");
-    if (videoContainer) {
-        videoContainer.style.display = 'none';
-    }
-    if (lightboxVideo) {
-        lightboxVideo.removeAttribute('src');
-    }
-
-    document.getElementById("lightbox-im").style.display = 'block';
-
     if (caption === '') {
         caption = img_elem.parentElement.parentElement.firstElementChild.textContent;
     }
@@ -385,43 +374,10 @@ function openLightBox(img_elem, caption) {
     lightbox.classList.remove('hidden');
 }
 
-function openVideoLightBox(embedUrl, sourceType, caption, event) {
-    if (event) {
-        event.stopPropagation();
-    }
-    pauseBackgroundVideo();
-
-    document.getElementById("lightbox-im").style.display = 'none';
-
-    if (caption) {
-        document.getElementById("lightbox-caption").textContent = caption;
-    }
-
-    var autoplayUrl = embedUrl.indexOf('?') >= 0 ? embedUrl + '&autoplay=1' : embedUrl + '?autoplay=1';
-    var videoContainer = document.getElementById("lightbox-video-container");
-    var lightboxVideo = document.getElementById("lightbox-video");
-    lightboxVideo.src = autoplayUrl;
-    videoContainer.style.display = 'block';
-
-    var lightbox = document.getElementById("lightbox");
-    lightbox.classList.add('visible');
-    lightbox.classList.remove('hidden');
-}
-
 function closeLightBox() {
     playBackgroundVideo();
 
-    var videoContainer = document.getElementById("lightbox-video-container");
-    var lightboxVideo = document.getElementById("lightbox-video");
-    if (videoContainer) {
-        videoContainer.style.display = 'none';
-    }
-    if (lightboxVideo) {
-        lightboxVideo.removeAttribute('src');
-    }
-
     document.getElementById("lightbox-im").removeAttribute('src');
-    document.getElementById("lightbox-im").style.display = 'block';
 
     var lightbox = document.getElementById("lightbox");
     lightbox.classList.remove('visible');

--- a/static/templates/vimeo_embed.mustache
+++ b/static/templates/vimeo_embed.mustache
@@ -1,6 +1,6 @@
 <div
     id="vimeo_{{vimeo_count}}"
-    class="vimeo_embed {{^thumbnail}}iframe-container video-clickable{{/thumbnail}}"
+    class="vimeo_embed {{^thumbnail}}iframe-container{{/thumbnail}}"
     {{#aspect_ratio}}style="padding-top: {{.}};"{{/aspect_ratio}}
     {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
     {{#loopend}}loopend="{{.}}"{{/loopend}}
@@ -16,7 +16,6 @@
         {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
         {{#loopend}}loopend="{{.}}"{{/loopend}}
     ></iframe>
-    <div class="video-overlay" onclick="openVideoLightBox('https://player.vimeo.com/video/{{vimeo}}?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479', 'vimeo', '', event);"></div>
     {{/thumbnail}}
 </div>
 

--- a/static/templates/youtube_embed.mustache
+++ b/static/templates/youtube_embed.mustache
@@ -1,9 +1,8 @@
-<div class="iframe-container video-clickable" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
+<div class="iframe-container" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
     <iframe
         src="https://www.youtube.com/embed/{{youtube}}?controls=0"
         frameborder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen
     ></iframe>
-    <div class="video-overlay" onclick="openVideoLightBox('https://www.youtube.com/embed/{{youtube}}', 'youtube', '', event);"></div>
 </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -436,26 +436,6 @@ li.nav_inactive ul {
     pointer-events: none;
 }
 
-.video-clickable {
-    cursor: pointer;
-}
-
-.video-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    cursor: pointer;
-    background: rgba(0, 0, 0, 0);
-    transition: background 0.3s;
-}
-
-.video-clickable:hover .video-overlay {
-    background: rgba(0, 0, 0, 0.1);
-}
-
 .iframe-container iframe {
    border: 0;
    height: 100%;
@@ -632,23 +612,6 @@ li.nav_inactive ul {
   padding-top: 5%;
 }
 
-.lightbox-video-container {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  max-height: calc(100vh - 48px - 150px);
-  overflow: hidden;
-  display: none;
-}
-
-.lightbox-video-container iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-}
 
 /* The Close Button */
 .close {


### PR DESCRIPTION
## Summary
Backs out the video lightbox added in commit \`4a0444b\` (the squash of PR #12). The work is preserved in goal-branch history and remains in the \`new-layout\` branch for future re-application in a dedicated PR.

## What's removed
- \`render.js\`: \`openVideoLightBox()\` function and the video-mutex blocks at the top of \`openLightBox\` and inside \`closeLightBox\`
- \`index.html\`: \`<div id=\"lightbox-video-container\">\` block with iframe
- \`stylesheet.css\`: \`.video-clickable\`, \`.video-overlay\`, \`.lightbox-video-container\` rules
- \`static/templates/vimeo_embed.mustache\`: \`video-clickable\` class on wrapper, \`<div class=\"video-overlay\">\` onclick handler
- \`static/templates/youtube_embed.mustache\`: same as Vimeo

## What's kept
- The image lightbox path in \`openLightBox\` / \`closeLightBox\` is untouched
- The \`var lightbox = document.getElementById(\"lightbox\")\` declaration in \`closeLightBox\` (4a0444b also fixed a pre-existing bare-undeclared-variable bug — that fix stays since it's useful regardless)
- Vimeo/YouTube embeds still render normally and play in-place via the standard iframe controls; you just don't get a click-to-fullscreen-lightbox interaction

## Why
Video lightbox alignment had recurring issues across 7 commits in \`new-layout\` (see vault PR #113 archaeology doc). The aspect-ratio fix that landed in #12 was the cleanest known approach but the user wants to verify it visually in a dedicated cycle rather than ship it in this bundle.

## Net diff
5 files, +2 / -88 — mostly code removal.

## Test plan
- [ ] (User-side) Visit any page with a Vimeo or YouTube embed → embed plays inline normally
- [ ] (User-side) Open any photo lightbox → BUY PRINT button still appears centered
- [ ] (User-side) Confirm no console errors (\`openVideoLightBox\` no longer referenced anywhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)