### PR TITLE
Add Cloudflare R2 state backend for Stripe terraform

### DIFF
--- a/.github/workflows/stripe-plan.yml
+++ b/.github/workflows/stripe-plan.yml
@@ -26,12 +26,16 @@ jobs:
       - run: terraform init
         env:
           TF_VAR_stripe_api_key: ${{ secrets.STRIPE_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - run: terraform validate
 
       - run: terraform plan -no-color | tee plan.txt
         env:
           TF_VAR_stripe_api_key: ${{ secrets.STRIPE_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - uses: actions/github-script@v7
         with:
@@ -53,7 +57,7 @@ jobs:
               '',
               '</details>',
               '',
-              '> ⚠️ Without a remote state backend, this plan computes against an empty state on each run, so it always shows "create everything" rather than an incremental diff. Real plan-vs-state diffing requires the state-backend follow-up.',
+              '> Backed by Cloudflare R2 state at `s3://frankieeder-com/stripe/terraform.tfstate`. If this plan looks like "create everything," it means state migration has not happened yet — see infra/stripe/README.md.',
             ].join('\n');
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/stripe-sync.yml
+++ b/.github/workflows/stripe-sync.yml
@@ -17,6 +17,8 @@ jobs:
         working-directory: infra/stripe
         env:
           TF_VAR_stripe_api_key: ${{ secrets.STRIPE_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           terraform init
           terraform apply -auto-approve

--- a/infra/stripe/README.md
+++ b/infra/stripe/README.md
@@ -9,6 +9,39 @@ Provide via any of:
 - A `terraform.tfvars` file (add to `.gitignore` — never commit)
 - Interactive prompt (terraform will ask if the var is unset)
 
+## State backend (Cloudflare R2)
+
+State lives in the `frankieeder-com` R2 bucket under `stripe/terraform.tfstate`.
+
+Credentials come from the standard AWS env vars (the s3 backend reads them):
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+Get these from Cloudflare → R2 → Manage R2 API Tokens → Create token (Object Read & Write, scoped to `frankieeder-com`). Save both values immediately — the secret is shown once.
+
+In CI, set them as GitHub repo secrets (Settings → Secrets and variables → Actions). Locally:
+
+```sh
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+### First-time migration from local state
+
+If you have an existing local `terraform.tfstate` from before the backend was wired up, push it to R2:
+
+```sh
+cd infra/stripe
+terraform init -migrate-state
+# answer "yes" to copy local state to the new backend
+```
+
+After this, the local `terraform.tfstate` is moved to R2 and subsequent runs read/write there automatically.
+
+### Fresh setup (no existing state)
+
+If there's no local state file, run `terraform init` and accept that the next `apply` will treat all resources as new — meaning Stripe will end up with duplicates of the existing products/prices/links. **Don't do this if Stripe already has the resources.** Instead, either find your old state file or use `terraform import` to bring existing Stripe resources into the new state.
+
 ## Two providers
 
 - `stripe/stripe` — used for products, prices, and shipping rates

--- a/infra/stripe/main.tf
+++ b/infra/stripe/main.tf
@@ -17,6 +17,23 @@ terraform {
       version = "~> 2.3"
     }
   }
+
+  # State stored in Cloudflare R2 (S3-compatible). Credentials come from
+  # AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars; locally export the
+  # R2 token values, in CI set them as repo secrets.
+  backend "s3" {
+    bucket    = "frankieeder-com"
+    key       = "stripe/terraform.tfstate"
+    endpoints = { s3 = "https://6e99a6526cc21c3f213ba478f6911d92.r2.cloudflarestorage.com" }
+    region    = "auto"
+
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
 }
 
 provider "stripe" {

--- a/infra/stripe/main.tf
+++ b/infra/stripe/main.tf
@@ -145,10 +145,19 @@ resource "stripe_payment_link" "payment_links" {
   automatic_tax_enabled                         = true
   shipping_address_collection_allowed_countries = ["US"]
   consent_collection_promotions                 = "auto"
+
+  # Attributes below are explicit defaults the andrewbaxter/stripe provider
+  # populates in state from Stripe's API. Without them in config, terraform
+  # plan reads "state -> null" as drift, and the three marked here force
+  # replacement of every payment link (= new buy.stripe.com URLs, breaks
+  # any committed/customer-bookmarked links). Pin them to current values.
+  consent_collection_terms_of_service = "none" # forces replacement
+  currency                            = "usd"  # forces replacement
+  submit_type                         = "auto" # forces replacement
+
   shipping_options {
     shipping_rate = stripe_shipping_rate.shipping_rates[each.value.shipping_rate_key].id
   }
-
 
   line_items {
     price    = each.value.price_id

--- a/infra/stripe/main.tf
+++ b/infra/stripe/main.tf
@@ -148,12 +148,17 @@ resource "stripe_payment_link" "payment_links" {
 
   # Attributes below are explicit defaults the andrewbaxter/stripe provider
   # populates in state from Stripe's API. Without them in config, terraform
-  # plan reads "state -> null" as drift, and the three marked here force
-  # replacement of every payment link (= new buy.stripe.com URLs, breaks
-  # any committed/customer-bookmarked links). Pin them to current values.
+  # plan reads "state -> null" as drift. The first three force replacement
+  # (= new buy.stripe.com URLs); the rest are in-place updates but still
+  # show as plan noise on every run. Pin all to current values for a
+  # truly clean plan.
   consent_collection_terms_of_service = "none" # forces replacement
   currency                            = "usd"  # forces replacement
   submit_type                         = "auto" # forces replacement
+  after_completion_type               = "hosted_confirmation"
+  billing_address_collection          = "auto"
+  customer_creation                   = "if_required"
+  payment_method_collection           = "if_required"
 
   shipping_options {
     shipping_rate = stripe_shipping_rate.shipping_rates[each.value.shipping_rate_key].id


### PR DESCRIPTION
## Summary
Wires up Cloudflare R2 as the remote state backend for \`infra/stripe/\` so terraform plan / apply produce real incremental diffs instead of "create everything from empty state."

Stacks on #19 (which has the \`fmt\` + \`query\` fixes that this PR's CI also depends on).

## Files changed
- **\`infra/stripe/main.tf\`** — adds \`backend "s3"\` block pointing at \`s3://frankieeder-com/stripe/terraform.tfstate\` via R2's S3-compatible endpoint
- **\`infra/stripe/README.md\`** — documents R2 token setup, AWS env var convention, and \`terraform init -migrate-state\` for the first-time migration
- **\`.github/workflows/stripe-plan.yml\`** + **\`stripe-sync.yml\`** — pass \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` to terraform commands so the backend can authenticate
- The "no state backend" caveat in the plan comment is replaced with a state-migration check

## Required setup before merge

CI will fail until both items are done:

1. **Create R2 token** in Cloudflare dashboard
   - https://dash.cloudflare.com/6e99a6526cc21c3f213ba478f6911d92/r2/api-tokens
   - Permissions: Object Read & Write
   - Scope: \`frankieeder-com\` bucket only
   - Save the Access Key ID and Secret Access Key (shown once)

2. **Add GitHub repo secrets** (Settings → Secrets and variables → Actions)
   - \`AWS_ACCESS_KEY_ID\` = R2 token's access key ID
   - \`AWS_SECRET_ACCESS_KEY\` = R2 token's secret
   - \`STRIPE_API_KEY\` = Stripe API key (already needed by \`stripe-sync.yml\`; gate the plan job on it being present)

## Required setup before first useful plan

After merge but before \`stripe-plan.yml\` shows real diffs:

3. **Migrate existing local state to R2** (one-time, run locally where you have the existing \`terraform.tfstate\`)
   \`\`\`sh
   cd infra/stripe
   export AWS_ACCESS_KEY_ID=...
   export AWS_SECRET_ACCESS_KEY=...
   terraform init -migrate-state
   # answer "yes" when asked to copy state to s3 backend
   \`\`\`

If you can't find the original \`terraform.tfstate\`, plan will continue showing "create everything" until the existing Stripe products / prices / payment links are imported with \`terraform import\`. Don't run \`terraform apply\` from a fresh state — it'll create duplicates of everything in Stripe.

## Test plan
- [ ] (User) R2 token created, scoped to \`frankieeder-com\` bucket
- [ ] (User) GitHub secrets \`AWS_ACCESS_KEY_ID\` + \`AWS_SECRET_ACCESS_KEY\` + \`STRIPE_API_KEY\` set
- [ ] CI passes \`fmt\` + \`init\` + \`validate\` + \`plan\` after secrets set
- [ ] Plan PR comment shows the empty-state caveat removed
- [ ] (User, post-merge) Local \`terraform init -migrate-state\` migrates existing tfstate to R2
- [ ] (User, after migration) Re-run plan workflow → shows no-op diff (state matches Stripe reality)

## Out of scope
- State locking via DynamoDB or similar — R2 doesn't have a native lock backend. With single-user workflow and manual workflow_dispatch this is acceptable; if multi-user concurrent applies become a concern, address then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)