### PR TITLE
Simplify BUY PRINT dropdown handlers (-41 lines)

### DIFF
--- a/render.js
+++ b/render.js
@@ -282,7 +282,7 @@ function openLightBox(img_elem, caption) {
 
     if (buy_print_dropdown) {
         buy_print_dropdown.innerHTML = '';
-        buy_print_dropdown.style.display = 'none';
+        buy_print_dropdown.classList.remove('visible');
         if (PAYMENT_LINKS && Object.keys(PAYMENT_LINKS).length > 0) {
             var sizeOrder = ['4_6', '6_9', '8_12', '12_18', '16_24', '24_36', '32_48'];
             for (var i = 0; i < sizeOrder.length; i++) {
@@ -296,75 +296,27 @@ function openLightBox(img_elem, caption) {
                     dropdownItem.target = '_blank';
                     dropdownItem.className = 'buy-print-dropdown-item';
                     dropdownItem.textContent = sizeLabel + ' - $' + priceDollars;
-                    dropdownItem.style.display = 'block';
-                    dropdownItem.style.width = '100%';
                     buy_print_dropdown.appendChild(dropdownItem);
                 }
             }
 
+            // Hover shows dropdown; click pins it open until clicked again.
+            // mouseleave on .buy-print-container fires only when leaving the
+            // whole subtree, so the dropdown (a DOM child) stays hovered.
             var buy_print_container = buy_print_dropdown.parentElement;
             if (buy_print_container && buy_print_container.classList.contains('buy-print-container')) {
-                var dropdownVisible = false;
-
+                var dropdownPinned = false;
                 buy_print_container.onmouseenter = function() {
-                    if (!dropdownVisible) {
-                        buy_print_dropdown.style.display = 'block';
-                        buy_print_dropdown.style.opacity = '0';
-                        setTimeout(function() {
-                            buy_print_dropdown.style.transition = 'opacity 0.2s ease';
-                            buy_print_dropdown.style.opacity = '1';
-                        }, 10);
-                    }
+                    buy_print_dropdown.classList.add('visible');
                 };
-                buy_print_container.onmouseleave = function(e) {
-                    if (!dropdownVisible && !buy_print_container.contains(e.relatedTarget)) {
-                        buy_print_dropdown.style.transition = 'opacity 0.15s ease';
-                        buy_print_dropdown.style.opacity = '0';
-                        setTimeout(function() {
-                            if (!dropdownVisible) {
-                                buy_print_dropdown.style.display = 'none';
-                            }
-                        }, 150);
-                    }
+                buy_print_container.onmouseleave = function() {
+                    if (!dropdownPinned) buy_print_dropdown.classList.remove('visible');
                 };
-                buy_print_dropdown.onmouseenter = function() {
-                    if (dropdownVisible) {
-                        buy_print_dropdown.style.display = 'block';
-                        buy_print_dropdown.style.opacity = '1';
-                    }
+                buy_print_elem.onclick = function(e) {
+                    e.preventDefault();
+                    dropdownPinned = !dropdownPinned;
+                    buy_print_dropdown.classList.toggle('visible', dropdownPinned);
                 };
-                buy_print_dropdown.onmouseleave = function(e) {
-                    if (!dropdownVisible && !buy_print_container.contains(e.relatedTarget)) {
-                        buy_print_dropdown.style.transition = 'opacity 0.15s ease';
-                        buy_print_dropdown.style.opacity = '0';
-                        setTimeout(function() {
-                            if (!dropdownVisible) {
-                                buy_print_dropdown.style.display = 'none';
-                            }
-                        }, 150);
-                    }
-                };
-
-                var toggleDropdown = function(e) {
-                    if (e) {
-                        e.preventDefault();
-                    }
-                    dropdownVisible = !dropdownVisible;
-                    buy_print_dropdown.style.display = dropdownVisible ? 'block' : 'none';
-                    if (dropdownVisible) {
-                        buy_print_dropdown.style.opacity = '0';
-                        setTimeout(function() {
-                            buy_print_dropdown.style.transition = 'opacity 0.2s ease';
-                            buy_print_dropdown.style.opacity = '1';
-                        }, 10);
-                    } else {
-                        buy_print_dropdown.style.transition = 'opacity 0.15s ease';
-                        buy_print_dropdown.style.opacity = '0';
-                    }
-                    return false;
-                };
-
-                buy_print_elem.onclick = toggleDropdown;
             }
         }
     }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -485,7 +485,9 @@ li.nav_inactive ul {
 }
 
 #lightbox-buy-print-dropdown {
-    display: none;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
     position: absolute;
     bottom: 100%;
     left: 50%;
@@ -499,6 +501,11 @@ li.nav_inactive ul {
     overflow: hidden;
     flex-direction: column;
     padding-top: 4px;
+}
+
+#lightbox-buy-print-dropdown.visible {
+    visibility: visible;
+    opacity: 1;
 }
 
 #lightbox-buy-print-dropdown .buy-print-dropdown-item {


### PR DESCRIPTION
## Summary
Addresses [your review comment on PR #16](https://github.com/frankieeder/frankieeder.github.io-dev/pull/16#discussion_r2497856947) — *"can this be simplified at all?"* on \`render.js:368\`.

The original block in \`openLightBox()\` was 60+ lines of imperative state coordination: 6 event handlers, 4 \`setTimeout\` chains, and a \`dropdownVisible\` flag captured in 5 closures. Most of that was working around the fact that \`display: none\` can't be CSS-transitioned.

## What changed

**\`stylesheet.css\`** — replaces \`display: none\` on \`#lightbox-buy-print-dropdown\` with \`visibility: hidden; opacity: 0\` + transition; adds a \`.visible\` modifier that flips both. CSS now handles all fade-in / fade-out timing.

**\`render.js\`** — collapses the dropdown setup to:
\`\`\`js
buy_print_container.onmouseenter = () => buy_print_dropdown.classList.add('visible');
buy_print_container.onmouseleave = () => {
    if (!dropdownPinned) buy_print_dropdown.classList.remove('visible');
};
buy_print_elem.onclick = (e) => {
    e.preventDefault();
    dropdownPinned = !dropdownPinned;
    buy_print_dropdown.classList.toggle('visible', dropdownPinned);
};
\`\`\`

The handlers on \`buy_print_dropdown\` itself (mouseenter/mouseleave) were redundant: \`mouseleave\` on the container only fires when leaving the entire subtree, so the dropdown (a DOM child) is already covered.

Also drops two redundant inline styles in the dropdown-item creation loop (\`display: block\` and \`width: 100%\`) since the \`.buy-print-dropdown-item\` CSS rule already sets both with \`!important\`.

## Net diff
\`render.js\` -52 / +12 within the BUY PRINT block; \`stylesheet.css\` +9 / -1. Total: +20 / -61.

## Behavior
Identical user experience:
- Hover BUY PRINT → dropdown fades in
- Move mouse to dropdown → stays open (subtree covered by single \`mouseleave\` listener on container)
- Click BUY PRINT → pins dropdown open even after mouseleave
- Click again → dismisses

## Test plan
- [ ] (User-side) Cloudflare preview → hover BUY PRINT → dropdown fades in smoothly
- [ ] Mouse onto dropdown items → stays visible
- [ ] Mouse off entire button + dropdown area → fades out
- [ ] Click button → dropdown pins open
- [ ] Click button again → closes
- [ ] Click a size → opens Stripe checkout in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)