### PR TITLE
Add video lightbox with vertical+horizontal centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
         <span class="close cursor" onclick="closeLightBox()">&times;</span>
         <div class="lightbox-content">
             <img id="lightbox-im" src="img_nature_wide.jpg">
-            <!-- <div id="lightbox-video-container" class="lightbox-video-container">
+            <div id="lightbox-video-container" class="lightbox-video-container">
                 <iframe id="lightbox-video" src="" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
-            </div> -->
+            </div>
             <div class="lightbox-caption-container">
                 <h2 id="lightbox-title"></h2>
                 <h4 id="lightbox-subtitle"></h4>

--- a/render.js
+++ b/render.js
@@ -313,6 +313,11 @@ function openLightBox(img_elem, caption) {
         lightboxVideo.removeAttribute('src');
     }
 
+    var buyPrintContainer = document.querySelector(".buy-print-container");
+    if (buyPrintContainer) {
+        buyPrintContainer.style.display = '';
+    }
+
     var contentCard = null;
     var element = img_elem;
     while (element && !contentCard) {
@@ -536,6 +541,35 @@ function closeLightBox() {
     var lightbox = document.getElementById("lightbox");
     lightbox.classList.remove('visible');
     lightbox.classList.add('hidden');
+}
+
+function openVideoLightBox(embedUrl, sourceType, caption, event) {
+    if (event) {
+        event.stopPropagation();
+    }
+    pauseBackgroundVideo();
+
+    document.getElementById("lightbox-im").style.display = 'none';
+
+    var buyPrintContainer = document.querySelector(".buy-print-container");
+    if (buyPrintContainer) {
+        buyPrintContainer.style.display = 'none';
+    }
+
+    var videoContainer = document.getElementById("lightbox-video-container");
+    var lightboxVideo = document.getElementById("lightbox-video");
+
+    var autoplayUrl = embedUrl.indexOf('?') >= 0 ? embedUrl + '&autoplay=1' : embedUrl + '?autoplay=1';
+    lightboxVideo.src = autoplayUrl;
+    videoContainer.style.display = 'flex';
+
+    if (caption) {
+        document.getElementById("lightbox-title").textContent = caption;
+    }
+
+    var lightbox = document.getElementById("lightbox");
+    lightbox.classList.remove('hidden');
+    lightbox.classList.add('visible');
 }
 
 

--- a/static/templates/vimeo_embed.mustache
+++ b/static/templates/vimeo_embed.mustache
@@ -1,6 +1,6 @@
 <div
     id="vimeo_{{vimeo_count}}"
-    class="vimeo_embed {{^thumbnail}}iframe-container{{/thumbnail}}"
+    class="vimeo_embed {{^thumbnail}}iframe-container video-clickable{{/thumbnail}}"
     {{#aspect_ratio}}style="padding-top: {{.}};"{{/aspect_ratio}}
     {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
     {{#loopend}}loopend="{{.}}"{{/loopend}}
@@ -16,6 +16,6 @@
         {{#loopstart}}loopstart="{{.}}"{{/loopstart}}
         {{#loopend}}loopend="{{.}}"{{/loopend}}
     ></iframe>
+    <div class="video-overlay" onclick="openVideoLightBox('https://player.vimeo.com/video/{{vimeo}}?badge=0&autopause=0&player_id=0&app_id=58479', 'vimeo', '', event);"></div>
     {{/thumbnail}}
 </div>
-

--- a/static/templates/youtube_embed.mustache
+++ b/static/templates/youtube_embed.mustache
@@ -1,8 +1,9 @@
-<div class="iframe-container" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
+<div class="iframe-container video-clickable" {{#aspect_ratio}}style="padding-top: {{.}}"{{/aspect_ratio}}>
     <iframe
         src="https://www.youtube.com/embed/{{youtube}}?controls=0"
         frameborder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen
     ></iframe>
+    <div class="video-overlay" onclick="openVideoLightBox('https://www.youtube.com/embed/{{youtube}}?controls=0', 'youtube', '', event);"></div>
 </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -668,6 +668,8 @@ li.nav_inactive ul {
 .lightbox-content {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   position: relative;
   flex: 1 1 0;
   align-self: stretch;
@@ -687,25 +689,38 @@ li.nav_inactive ul {
     display: block;
   }
 
-/* .lightbox-video-container {
-  flex: 0 0 auto;
-  overflow: hidden;
-  position: relative;
-  width: 100%;
-  height: 0;
-  padding-top: 56.25%;
-  display: block;
+.lightbox-video-container {
+  display: none;
+  width: min(90vw, 1280px);
+  max-height: 80vh;
+  aspect-ratio: 16 / 9;
+  margin: auto;
 }
 
 .lightbox-video-container iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-clickable {
+  position: relative;
+  cursor: pointer;
+}
+
+.video-overlay {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  border: 0;
-  display: block;
-} */
+  cursor: pointer;
+  z-index: 1;
+}
+
+.video-overlay:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
 
 /* The Close Button */
 .close {


### PR DESCRIPTION
## Summary
Re-introduces the video lightbox functionality, fixing the recurring centering issue that broke prior attempts (see vault PR #113 archaeology + this repo's `LAYOUT_REVIEW.md` P0 finding).

## What's new
- `openVideoLightBox()` function in `render.js` with mutual-exclusion (hides image lightbox + BUY PRINT container when video is shown)
- `lightbox-video-container` div in `index.html` uncommented (was null-crashing every Vimeo/YouTube click)
- `.lightbox-video-container` CSS using `aspect-ratio: 16 / 9` + `width: min(90vw, 1280px); max-height: 80vh` for clamped sizing
- `.lightbox-content` gains `align-items: center; justify-content: center` for natural vertical+horizontal centering of the video container
- `.video-clickable` / `.video-overlay` classes on Vimeo + YouTube embed templates with onclick handlers
- `openLightBox()` restores `.buy-print-container` visibility (mutual-exclusion return path)

## Centering approach
- `.lightbox-content` uses flex column with `align-items: center; justify-content: center` — the video container centers naturally on both axes
- Container uses `aspect-ratio: 16 / 9` (modern CSS) instead of the previously-broken `padding-top: 56.25%` hack
- Width clamped to `min(90vw, 1280px)`, height to `80vh` — prevents overflow at large viewports
- `margin: auto` on the container as belt-and-suspenders for horizontal centering

## Root cause of prior failures (from LAYOUT_REVIEW.md P0 + archaeology)
The old `padding-top: 56.25%` + `height: 0` approach requires `position: absolute` children and interacts badly with flex parents. Previous attempts also used `height: 90%` which collapsed in a flex column container with no explicit parent height. `aspect-ratio` sidesteps all of this.

## Test plan
- [ ] (User-side) Click a Vimeo tile → video lightbox opens, centered both axes
- [ ] (User-side) Click a YouTube tile → same
- [ ] (User-side) Image lightbox still works (BUY PRINT button, dropdown, all functional)
- [ ] (User-side) Close video lightbox → iframe src cleared, video stops
- [ ] (User-side) Switch image ↔ video lightbox → mutual exclusion holds
- [ ] (User-side) Test at 320px / 768px / 1280px / 1920px viewport widths

## Out of scope (P0/P1 findings from S3 review for follow-up)
- Keyboard navigation (no Escape handler, no `tabindex` on tiles, `<span>` close button) — separate PR
- Image alt text plumbing (`alt="pic"` everywhere) — separate PR

Lineage: branches off `frankieeder-com/new-layout` (goal branch with S1 tile layout + S3 architecture review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)