### PR TITLE
Add Playwright + pytest E2E test infrastructure

### DIFF
--- a/.github/workflows/lightbox-tests.yml
+++ b/.github/workflows/lightbox-tests.yml
@@ -1,0 +1,56 @@
+name: Lightbox E2E
+
+# Run on PRs that touch the lightbox surface area: the render JS, the
+# styling, the page shell, the content data, the mustache templates, and
+# the tests themselves.  Other PRs skip this workflow entirely.
+on:
+  pull_request:
+    paths:
+      - 'render.js'
+      - 'stylesheet.css'
+      - 'index.html'
+      - 'content.js'
+      - 'static/templates/**'
+      - 'tests/**'
+      - 'requirements-dev.txt'
+      - 'pytest.ini'
+      - 'Makefile'
+      - '.github/workflows/lightbox-tests.yml'
+  workflow_dispatch:
+
+# Install and test steps are delegated to the Makefile so local + CI
+# share a single source of truth.  The only CI-specific layers here are
+# Python setup and Playwright browser caching (~150MB, worth caching
+# between runs).
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('requirements-dev.txt') }}
+
+      - name: Install test deps
+        run: make install-test-deps
+
+      - name: Run lightbox tests
+        run: make test
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ venv/
 *.DS_Store
 .env
 .envrc
+
+# Python / pytest / Playwright
+__pycache__/
+*.pyc
+.pytest_cache/
+test-results/
+playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: serve serve-node install
+.PHONY: serve serve-node install run open install-test-deps test
 
 PORT = 8005
 
@@ -7,3 +7,23 @@ run:
 
 open:
 	open http://localhost:$(PORT)
+
+# Install Playwright + pytest and the headless Chromium binary they need.
+# Run once after cloning (or after bumping requirements-dev.txt).
+#
+# --with-deps tells Playwright to also install the system libraries it
+# needs (libnss3, libatk*, etc.).  On Linux this shells out to apt-get
+# and may prompt for sudo.  On macOS / Windows it's a no-op — Playwright
+# only does the apt path on Debian-family Linux.
+#
+# This target is the single source of truth for test setup: the CI
+# workflow at .github/workflows/lightbox-tests.yml invokes it directly.
+install-test-deps:
+	pip install -r requirements-dev.txt
+	python -m playwright install --with-deps chromium
+
+# Run the end-to-end lightbox tests.  Spins up its own http.server, so no
+# need to `make run` first.  Also the single source of truth invoked by
+# the CI workflow.
+test:
+	pytest tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -v --tb=short

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=7.4
+pytest-playwright>=0.4.4
+playwright>=1.40

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest fixtures for the lightbox end-to-end tests.
+
+Spins up `python3 -m http.server` in a background thread serving the repo
+root, so tests can hit a real localhost URL without depending on
+Cloudflare previews or external services.  The fixture is session-scoped:
+the server starts once for the whole pytest run and tears down at exit.
+"""
+import http.server
+import socketserver
+import threading
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler that doesn't spam stderr with request logs."""
+
+    def log_message(self, format, *args):  # noqa: A002 (signature is fixed)
+        pass
+
+
+@pytest.fixture(scope="session")
+def server_url():
+    """Serve the repo root over HTTP for the duration of the test session.
+
+    Binds to port 0 so the OS picks a free port — avoids clashes with the
+    user's `make run` server or with parallel test runs in CI.
+    """
+    handler = partial(_QuietHandler, directory=str(REPO_ROOT))
+    # allow_reuse_address makes flaky teardown less painful in dev.
+    socketserver.TCPServer.allow_reuse_address = True
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,22 @@
+"""Smoke test for the e2e test infrastructure itself.
+
+Confirms three things that every more-specific test depends on:
+
+1. The session-scoped `server_url` fixture from conftest.py is serving
+   the repo root over HTTP.
+2. Playwright can launch headless Chromium and reach that URL.
+3. The page actually renders (i.e. mustache templates load, content.js
+   evaluates, and at least one `.content` card appears in the DOM).
+
+If this test fails, no other e2e test in this repo is meaningful — fix
+this first.  Kept deliberately content-agnostic so it doesn't break when
+the homepage layout or copy changes.
+"""
+from playwright.sync_api import Page
+
+
+def test_homepage_renders(page: Page, server_url: str):
+    page.goto(server_url)
+    # Mustache templates are fetched after page load, then content cards
+    # are interpolated into #contents.  Wait for at least one to appear.
+    page.wait_for_selector(".content", timeout=10_000)


### PR DESCRIPTION
## Summary
Reusable rails for browser-based end-to-end testing. No content-specific tests yet — those land in follow-up PRs (lightbox tests in #29, eventually nav / buy-print / etc.). Branch off `main` so this can merge independently of the lightbox stack.

## What's included
- **`requirements-dev.txt`** — `pytest` + `pytest-playwright` + `playwright`
- **`pytest.ini`** — `testpaths = tests`, short tracebacks, verbose
- **`tests/conftest.py`** — session-scoped fixture that runs `http.server` on a random free port serving the repo root. No external dependency on Cloudflare previews → works offline, deterministic
- **`tests/test_smoke.py`** — minimal smoke test that confirms fixture + Playwright + page rendering all work end-to-end. If this fails, no other e2e test is meaningful. Content-agnostic on purpose
- **`Makefile`** — `make install-test-deps` + `make test`. Single source of truth invoked by both local dev and CI
- **`.github/workflows/lightbox-tests.yml`** — path-gated CI workflow. Delegates install + run to the Makefile targets. Caches Playwright browser binaries (~150MB) between runs
- **`.gitignore`** — `__pycache__`, `.pytest_cache`, `test-results`, `playwright-report`

## How to run locally
```bash
make install-test-deps   # once, after cloning
make test                # runs all tests in headless Chromium
```

`make install-test-deps` uses `playwright install --with-deps chromium`. On macOS / Windows `--with-deps` is a no-op; on Debian-family Linux it shells out to `apt-get` and may prompt for sudo.

## Path filter
Workflow currently triggers on lightbox-relevant paths (`render.js`, `stylesheet.css`, `index.html`, `content.js`, `static/templates/**`) plus the infra files themselves. Expand the filter as more test scopes are added.

## Stack
- **This PR** — generic infra, base = `main`
- **#27** — lightbox margin fixes (independent, base = `main`)
- **#29** — lightbox-specific tests (depends on both — base = `style/tighten-video-lightbox-margins`, will pick up this infra once both this PR + #27 merge to main)

## CI plan after this lands
Once merged, future PRs touching the filtered paths automatically run the smoke test. Once #29 lands too, the same workflow runs the lightbox geometry tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)