### PR TITLE
Add E2E geometry tests for video lightbox

### DIFF
--- a/tests/test_video_lightbox.py
+++ b/tests/test_video_lightbox.py
@@ -1,0 +1,137 @@
+"""End-to-end geometry tests for the video lightbox.
+
+Each test opens the site in a headless browser at a specific viewport
+size, clicks the first video tile, and measures the lightbox via DOM
+bounding boxes.  We assert the invariants we actually care about:
+
+- video container is horizontally centered (sanity check)
+- the [video + caption] block is vertically centered — guards the fix
+  from PR #27 (`margin: auto` previously broke this)
+- video container exposes the expected aspect ratio
+- video container never overflows the viewport
+
+A future PR will plumb per-video aspect ratios (square, portrait, 2.39:1
+cinematic) through to the lightbox — at that point the aspect-ratio test
+will become parametrized over the tile's `aspect_ratio` field rather than
+hard-coded to 16:9.  Keeping the existing assertion explicit so the
+behavior change is loud when it lands.
+"""
+import pytest
+from playwright.sync_api import Page
+
+
+# Common viewport sizes — covers mobile portrait, tablet, small desktop,
+# standard desktop.  Add more as we find regressions.
+VIEWPORTS = [
+    pytest.param(320, 568, id="320x568-mobile-portrait"),
+    pytest.param(768, 1024, id="768x1024-tablet-portrait"),
+    pytest.param(1280, 720, id="1280x720-small-desktop"),
+    pytest.param(1920, 1080, id="1920x1080-desktop"),
+]
+
+# Sub-pixel rounding + flex centering means we can't expect pixel-perfect
+# equality.  2px of slop is enough to absorb rounding without hiding real
+# layout bugs (the regressions we've seen were tens of px off).
+MARGIN_TOLERANCE_PX = 2
+
+# 16:9 ≈ 1.7777.  Aspect ratio is set in CSS, not derived from layout, so
+# the rendered ratio should be exact modulo sub-pixel rounding.
+ASPECT_RATIO_TOLERANCE = 0.02
+
+
+@pytest.fixture
+def open_first_video(page: Page, server_url: str):
+    """Return a helper that resizes the viewport, opens the page, and
+    clicks the first video tile.  Yields the Page positioned with the
+    lightbox visible.
+    """
+    def _open(viewport_w: int, viewport_h: int) -> Page:
+        page.set_viewport_size({"width": viewport_w, "height": viewport_h})
+        page.goto(server_url)
+
+        # Content is rendered async (mustache templates are fetched then
+        # interpolated into #contents).  Wait for the first interactive
+        # video tile to appear before clicking.
+        page.wait_for_selector(".video-overlay", timeout=10_000)
+        page.locator(".video-overlay").first.click()
+
+        # `.visible` is added to #lightbox once the open animation starts.
+        page.wait_for_selector(".lightbox.visible", timeout=5_000)
+
+        # And wait until the layout has settled (height becomes non-zero).
+        page.wait_for_function(
+            "document.getElementById('lightbox-video-container').offsetHeight > 0",
+            timeout=5_000,
+        )
+        return page
+
+    return _open
+
+
+@pytest.mark.parametrize("vw,vh", VIEWPORTS)
+def test_video_container_horizontally_centered(open_first_video, vw, vh):
+    """Left margin from viewport edge == right margin (flex centering)."""
+    page = open_first_video(vw, vh)
+    box = page.locator("#lightbox-video-container").bounding_box()
+    left = box["x"]
+    right = vw - (box["x"] + box["width"])
+    assert abs(left - right) <= MARGIN_TOLERANCE_PX, (
+        f"video container not horizontally centered: "
+        f"left={left:.1f}px, right={right:.1f}px (Δ={abs(left - right):.1f}px)"
+    )
+
+
+@pytest.mark.parametrize("vw,vh", VIEWPORTS)
+def test_video_plus_caption_vertically_centered(open_first_video, vw, vh):
+    """Whitespace above the video == whitespace below the caption.
+
+    Before PR #27's second commit, `margin: auto` on the video container
+    absorbed free space asymmetrically: ~50px gap above, ~24px below the
+    caption.  This test would have caught that.
+    """
+    page = open_first_video(vw, vh)
+    video = page.locator("#lightbox-video-container").bounding_box()
+    caption = page.locator(".lightbox-caption-container").bounding_box()
+
+    top = video["y"]
+    bottom = vh - (caption["y"] + caption["height"])
+    assert abs(top - bottom) <= MARGIN_TOLERANCE_PX, (
+        f"[video+caption] block not vertically centered: "
+        f"top={top:.1f}px, bottom={bottom:.1f}px (Δ={abs(top - bottom):.1f}px)"
+    )
+
+
+@pytest.mark.parametrize("vw,vh", VIEWPORTS)
+def test_video_container_has_16_9_aspect_ratio(open_first_video, vw, vh):
+    """The lightbox currently hard-codes `aspect-ratio: 16 / 9`.
+
+    When per-video aspect ratios land (square/portrait/cinematic), this
+    test should be parametrized over the source tile's `aspect_ratio`
+    field instead of asserting a constant.
+    """
+    page = open_first_video(vw, vh)
+    box = page.locator("#lightbox-video-container").bounding_box()
+    ratio = box["width"] / box["height"]
+    assert abs(ratio - 16 / 9) < ASPECT_RATIO_TOLERANCE, (
+        f"aspect ratio={ratio:.3f}, expected ~1.778 (16:9)"
+    )
+
+
+@pytest.mark.parametrize("vw,vh", VIEWPORTS)
+def test_video_container_fits_inside_viewport(open_first_video, vw, vh):
+    """Video container must not overflow the viewport in any direction.
+
+    Catches the class of bug where the width formula picks a value larger
+    than the available height can accommodate (or vice versa) and the
+    container clips against `.lightbox { overflow: hidden }`.
+    """
+    page = open_first_video(vw, vh)
+    box = page.locator("#lightbox-video-container").bounding_box()
+    assert box["x"] >= 0, f"overflows left: x={box['x']:.1f}"
+    assert box["y"] >= 0, f"overflows top: y={box['y']:.1f}"
+    assert box["x"] + box["width"] <= vw + MARGIN_TOLERANCE_PX, (
+        f"overflows right: right={box['x'] + box['width']:.1f}, vw={vw}"
+    )
+    assert box["y"] + box["height"] <= vh + MARGIN_TOLERANCE_PX, (
+        f"overflows bottom: bottom={box['y'] + box['height']:.1f}, vh={vh}"
+    )


### PR DESCRIPTION
## Summary
Lightbox-specific E2E tests. Single file: `tests/test_video_lightbox.py`. Stacked on top of #27 so the "vertical centering" invariant is meaningful — it would have failed before #27's `margin: auto` removal in [`2b2f1b3`](https://github.com/frankieeder/frankieeder.github.io-dev/pull/27/commits/2b2f1b3).

The generic test infrastructure (deps, Makefile, conftest, CI workflow) is in **#30**.

> **Replaces #29.** I force-pushed #29 after a structural split, breaking the local-pull contract. Closing #29 and opening this branch fresh so the history-rewrite isn't sticky for anyone (including future-you with reflog browsing).

## What's tested
4 invariants × 4 viewports = 16 tests. Each opens the page at a viewport size, clicks the first video tile, then asserts:

1. **Horizontally centered** — `left == right` margin
2. **Vertically centered** — `top above video == bottom below caption`. The specific invariant the `margin: auto` removal from #27 fixed
3. **Aspect ratio 16:9** — currently locked; will be parametrized over the source tile's `aspect_ratio` field when per-video aspect ratios get plumbed through to the lightbox (future PR)
4. **Fits inside viewport** — no overflow / clipping in any direction

### Viewports
| ID | Size | Use case |
|---|---|---|
| `320x568-mobile-portrait` | 320×568 | iPhone SE |
| `768x1024-tablet-portrait` | 768×1024 | iPad |
| `1280x720-small-desktop` | 1280×720 | small laptop |
| `1920x1080-desktop` | 1920×1080 | standard desktop |

## Stack / merge order
1. **#27** lightbox margin fixes — base = `main`
2. **#30** generic E2E infra — base = `main`
3. **This PR** lightbox tests — base = `style/tighten-video-lightbox-margins`. Will pick up infra after #30 + #27 both merge to main and this rebases on top

Until #30 merges, the CI workflow isn't on this branch yet, so GitHub Actions won't auto-run. Once #30 lands and this rebases, the 16 tests will execute in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)